### PR TITLE
Pass correct argument to bufhidden var

### DIFF
--- a/autoload/wilder/renderer/vim_api.vim
+++ b/autoload/wilder/renderer/vim_api.vim
@@ -65,7 +65,7 @@ function! s:new_buf() abort
   call bufload(l:buf)
 
   call setbufvar(l:buf, '&buftype', 'nofile')
-  call setbufvar(l:buf, '&bufhidden', 1)
+  call setbufvar(l:buf, '&bufhidden', 'hide')
   call setbufvar(l:buf, '&swapfile', 0)
   call setbufvar(l:buf, '&undolevels', -1)
 


### PR DESCRIPTION
`bufhidden` expects string, not number. See https://vimhelp.org/options.txt.html#%27bufhidden%27

Otherwise on vim load I see error in messages:
```
Error detected while processing function <lambda>67[1]..<SNR>77_start[73]..<SNR>77_pre_hook[8]..<lambda>73[1]..<SNR>233_pre_hook[1]..<SNR>239_new[2]..<SNR>239_new_buf:
line    8:
E474: Invalid argument
```

Where 239 is [autoload/wilder/renderer/vim_api.vim](autoload/wilder/renderer/vim_api.vim) in my `:scriptnames`